### PR TITLE
Domain field added to Configuration struct and used in getAccessToken().

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -20,13 +20,13 @@ const (
 // UserCredential holds the username and password that the API should use to
 // authenticate to the REST API
 type UserCredential struct {
-	Username, Password string
+	Domain, Username, Password string
 }
 
 // Configuration settings for the API
 type Configuration struct {
-	Credentials                                              UserCredential
-	ServerURL, TLD, Tenant, apiPathURI, tokenPathURI, Domain string
+	Credentials                                      UserCredential
+	ServerURL, TLD, Tenant, apiPathURI, tokenPathURI string
 }
 
 // Server provides access to secrets stored in Thycotic Secret Server
@@ -134,8 +134,8 @@ func (s Server) getAccessToken() (string, error) {
 		"grant_type": {"password"},
 	}
 
-	if s.Domain != "" {
-		params["domain"] = []string{s.Domain}
+	if s.Credentials.Domain != "" {
+		params["domain"] = []string{s.Credentials.Domain}
 	}
 
 	body := strings.NewReader(params.Encode())

--- a/server/server.go
+++ b/server/server.go
@@ -25,8 +25,8 @@ type UserCredential struct {
 
 // Configuration settings for the API
 type Configuration struct {
-	Credentials                                      UserCredential
-	ServerURL, TLD, Tenant, apiPathURI, tokenPathURI string
+	Credentials                                              UserCredential
+	ServerURL, TLD, Tenant, apiPathURI, tokenPathURI, Domain string
 }
 
 // Server provides access to secrets stored in Thycotic Secret Server
@@ -131,6 +131,7 @@ func (s Server) getAccessToken() (string, error) {
 	body := strings.NewReader(url.Values{
 		"username":   {s.Credentials.Username},
 		"password":   {s.Credentials.Password},
+		"domain":     {s.Domain},
 		"grant_type": {"password"},
 	}.Encode())
 	data, _, err := handleResponse(http.Post(s.urlFor("token", ""), "application/x-www-form-urlencoded", body))

--- a/server/server.go
+++ b/server/server.go
@@ -128,12 +128,18 @@ func (s Server) accessResource(method, resource, path string, input interface{})
 // getAccessToken gets an OAuth2 Access Grant and returns the token
 // endpoint and get an accessGrant.
 func (s Server) getAccessToken() (string, error) {
-	body := strings.NewReader(url.Values{
+	params := url.Values{
 		"username":   {s.Credentials.Username},
 		"password":   {s.Credentials.Password},
-		"domain":     {s.Domain},
 		"grant_type": {"password"},
-	}.Encode())
+	}
+
+	if s.Domain != "" {
+		params["domain"] = []string{s.Domain}
+	}
+
+	body := strings.NewReader(params.Encode())
+
 	data, _, err := handleResponse(http.Post(s.urlFor("token", ""), "application/x-www-form-urlencoded", body))
 
 	if err != nil {


### PR DESCRIPTION
This enables an Active Directory domain name to be included in the server configuration, to be used when authenticating.

I haven't been able to test this against an endpoint which doesn't required Active Directory authentication. I am presuming that passing an empty value for "directory" where an AD domain name isn't needed won't cause any problems.