### PR TITLE
Implement SSH Key Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ The necessary configuration may also be configured from environment variables:
 | TSS_TENANT     | Name for tenants hosted in the Secret Server Cloud. This is prepended to the *.secretservercloud.com domain to determine the server URL. |
 | TSS_SERVER_URL | URL for servers not hosted in the cloud, eg: https://thycotic.mycompany.com/SecretServer                                                 |
 
-### Test #1
+### Test #1 - Read Secret Password
 Reads the secret with ID `1` or the ID passed in the `TSS_SECRET_ID` environment variable 
 and extracts the `password` field from it.
 
-### Test #2
+### Test #2 - Perform Secret CRUD
 Creates a secret with a fixed password using the values passed in the environment variables 
 below. It then reads the secret from the server, validates its values, updates it, and deletes 
 it.
@@ -132,13 +132,23 @@ it.
 | TSS_TEMPLATE_ID | The numeric ID of the template that defines the secret's fields               |
 | TSS_FIELD_ID    | The numeric ID of a field on the template that happens to be a password field |
 
-### Test #3
-Creates a secret with a generated password using the values passed in the environment variables 
-below. It then deletes the secret.
+### Test #3 - Perform CRUD for an SSH Key Secret
+Creates a secret with generated SSH keys using the values passed in the environment variables 
+below. It then reads the secret from the server, validates its values, updates it, and deletes it.
+
+| Env Var Name                | Description                                                                                                                       |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| TSS_SITE_ID                 | The numeric ID of the distributed engine site                                                                                     |
+| TSS_FOLDER_ID               | The numeric ID of the folder where the secret will be created                                                                     |
+| TSS_SSH_KEY_TEMPLATE_ID     | The numeric ID of the template that defines the secret's fields. This template must have extended mappings that support SSH keys. |
+| TSS_SSH_PUBLIC_FIELD_ID     | The numeric ID of the field that contains the generated public key.                                                               |
+| TSS_SSH_PRIVATE_FIELD_ID    | The numeric ID of the field that contains the generated private key.                                                              |
+| TSS_SSH_PASSPHRASE_FIELD_ID | The numeric ID of the field that contains the generated passphrase for the private key.                                           |
+
+### Test #4 - Password Generation
+Retrieves the template indicated in the environment variable below, iterates its fields, and 
+validates that we can generate a password value for every field that is a password field.
 
 | Env Var Name    | Description                                                                   |
 |-----------------|-------------------------------------------------------------------------------|
-| TSS_SITE_ID     | The numeric ID of the distributed engine site                                 |
-| TSS_FOLDER_ID   | The numeric ID of the folder where the secret will be created                 |
 | TSS_TEMPLATE_ID | The numeric ID of the template that defines the secret's fields               |
-| TSS_FIELD_ID    | The numeric ID of a field on the template that happens to be a password field |

--- a/server/secret.go
+++ b/server/secret.go
@@ -76,6 +76,11 @@ func (s Server) CreateSecret(secret Secret) (*Secret, error) {
 }
 
 func (s Server) UpdateSecret(secret Secret) (*Secret, error) {
+	if secret.SshKeyArgs != nil && (secret.SshKeyArgs.GenerateSshKeys || secret.SshKeyArgs.GeneratePassphrase) {
+		log.Printf("[WARN] SSH key and passphrase generation are ignored in updating the secret named '%s'. " +
+			"SSH generation is only supported during secret creation", secret.Name)
+		secret.SshKeyArgs = nil
+	}
 	return s.writeSecret(secret, "PUT", strconv.Itoa(secret.ID))
 }
 

--- a/server/secret.go
+++ b/server/secret.go
@@ -14,13 +14,14 @@ const resource = "secrets"
 type Secret struct {
 	Name                                                                       string
 	FolderID, ID, SiteID, SecretTemplateID                                     int
-	SecretPolicyID, PasswordTypeWebScriptID                                    int `json:",omitempty"`
+	SecretPolicyID, PasswordTypeWebScriptID                                    int           `json:",omitempty"`
 	LauncherConnectAsSecretID, CheckOutIntervalMinutes                         int
 	Active, CheckedOut, CheckOutEnabled                                        bool
 	AutoChangeEnabled, CheckOutChangePasswordEnabled, DelayIndexing            bool
 	EnableInheritPermissions, EnableInheritSecretPolicy, ProxyEnabled          bool
 	RequiresComment, SessionRecordingEnabled, WebLauncherRequiresIncognitoMode bool
 	Fields                                                                     []SecretField `json:"Items"`
+	SshKeyArgs                                                                 *SshKeyArgs   `json:",omitempty"`
 }
 
 // SecretField is an item (field) in the secret
@@ -29,6 +30,15 @@ type SecretField struct {
 	FieldName, Slug                       string
 	FieldDescription, Filename, ItemValue string
 	IsFile, IsNotes, IsPassword           bool
+}
+
+// SshKeyArgs control whether to generate an SSH key pair and a private key
+// passphrase when the secret template supports such generation.
+//
+// WARNING: this struct is only used for write _request_ bodies, and will not
+// be present in _response_ bodies.
+type SshKeyArgs struct {
+	GeneratePassphrase, GenerateSshKeys bool
 }
 
 // Secret gets the secret with id from the Secret Server of the given tenant
@@ -77,11 +87,43 @@ func (s Server) writeSecret(secret Secret, method string, path string) (*Secret,
 		return nil, err
 	}
 
-	fileFields, nonFileFields, err := secret.separateFileFields(template)
-	if err != nil {
-		return nil, err
+	// If the user did not request SSH key generation, separate the
+	// secret's fields into file fields and general fields, since we
+	// need to take active control of either providing the files'
+	// contents or deleting them. Otherwise, SSH key generation is
+	// responsible for populating the contents of the file fields.
+	//
+	// NOTE!!! This implies support for *either* file contents provided
+	// by the SSH generator *or* file contents provided by the user.
+	// This SDK does support secret templates that accept both kinds
+	// of file fields.
+	fileFields := make([]SecretField, 0)
+	generalFields := make([]SecretField, 0)
+	if secret.SshKeyArgs == nil || !secret.SshKeyArgs.GenerateSshKeys {
+		fileFields, generalFields, err = secret.separateFileFields(template)
+		if err != nil {
+			return nil, err
+		}
+		secret.Fields = generalFields
 	}
-	secret.Fields = nonFileFields
+
+	// If no SSH generation is called for, remove the SshKeyArgs value.
+	// Simply having the value in the Secret object causes the
+	// server to throw an error if the template is not geared towards
+	// SSH key generation, even if both of the struct's members are
+	// false.
+	if secret.SshKeyArgs != nil {
+		if !secret.SshKeyArgs.GenerateSshKeys && !secret.SshKeyArgs.GeneratePassphrase {
+			secret.SshKeyArgs = nil
+		}
+	}
+
+	// If the user specifies no items, perhaps because all the fields are
+	// generated, apply an empty array to keep the server from rejecting the
+	// request for missing a required element.
+	if secret.Fields == nil {
+		secret.Fields = make([]SecretField, 0)
+	}
 
 	if data, err := s.accessResource(method, resource, path, secret); err == nil {
 		if err = json.Unmarshal(data, writtenSecret); err != nil {

--- a/server/secret_template_test.go
+++ b/server/secret_template_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 )
 
-// TestSecretTemplate tests SecretTemplate
+// TestSecretTemplate tests SecretTemplate. Referred to as
+// "Test #4" in the README.
 func TestSecretTemplate(t *testing.T) {
 	tss, err := initServer()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -132,6 +133,7 @@ func (s Server) accessResource(method, resource, path string, input interface{})
 // uploadFile uploads the file described in the given fileField to the
 // secret at the given secretId as a multipart/form-data request.
 func (s Server) uploadFile(secretId int, fileField SecretField) error {
+	log.Printf("[DEBUG] uploading a file to the '%s' field with filename '%s'", fileField.Slug, fileField.Filename)
 	body := bytes.NewBuffer([]byte{})
 	path := fmt.Sprintf("%d/fields/%s", secretId, fileField.Slug)
 
@@ -144,7 +146,15 @@ func (s Server) uploadFile(secretId int, fileField SecretField) error {
 
 	// Create the multipart form
 	multipartWriter := multipart.NewWriter(body)
-	form, err := multipartWriter.CreateFormFile("file", fileField.Filename)
+	filename := fileField.Filename
+	if filename == "" {
+		filename = "File.txt"
+		log.Printf("[DEBUG] field has no filename, setting its filename to '%s'", filename)
+	} else if match, _ := regexp.Match("^[^.].*\\.\\w+$", []byte(filename)); !match {
+		filename = filename + ".txt"
+		log.Printf("[DEBUG] field has no filename extension, setting its filename to '%s'", filename)
+	}
+	form, err := multipartWriter.CreateFormFile("file", filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add the SshKeyArgs attribute to the Secret struct, which informs the server to generate public/private keys and, optionally, a private key passphrase, when creating a secret. 

This addresses #14 